### PR TITLE
Add ability to install packages + xgboost model deployer + example (#…

### DIFF
--- a/clipper_admin/clipper_admin/clipper_admin.py
+++ b/clipper_admin/clipper_admin/clipper_admin.py
@@ -240,7 +240,8 @@ class ClipperConnection(object):
                                labels=None,
                                container_registry=None,
                                num_replicas=1,
-                               batch_size=-1):
+                               batch_size=-1,
+                               pkgs_to_install=None):
         """Build a new model container Docker image with the provided data and deploy it as
         a model to Clipper.
 
@@ -289,6 +290,9 @@ class ClipperConnection(object):
             batches if `batch_size` queries are not immediately available.
             If the default value of -1 is used, Clipper will adaptively calculate the batch size for individual
             replicas of this model.
+        pkgs_to_install : list (of strings), optional
+            A list of the names of packages to install, using pip, in the container.
+            The names must be strings.
         Raises
         ------
         :py:exc:`clipper.UnconnectedException`
@@ -298,7 +302,7 @@ class ClipperConnection(object):
         if not self.connected:
             raise UnconnectedException()
         image = self.build_model(name, version, model_data_path, base_image,
-                                 container_registry)
+                                 container_registry, pkgs_to_install)
         self.deploy_model(name, version, input_type, image, labels,
                           num_replicas, batch_size)
 
@@ -307,7 +311,8 @@ class ClipperConnection(object):
                     version,
                     model_data_path,
                     base_image,
-                    container_registry=None):
+                    container_registry=None,
+                    pkgs_to_install=None):
         """Build a new model container Docker image with the provided data"
 
         This method builds a new Docker image from the provided base image with the local directory specified by
@@ -341,6 +346,9 @@ class ClipperConnection(object):
             The Docker container registry to push the freshly built model to. Note
             that if you are running Clipper on Kubernetes, this registry must be accesible
             to the Kubernetes cluster in order to fetch the container from the registry.
+        pkgs_to_install : list (of strings), optional
+            A list of the names of packages to install, using pip, in the container.
+            The names must be strings.
         Returns
         -------
         str :
@@ -363,6 +371,11 @@ class ClipperConnection(object):
 
         _validate_versioned_model_name(name, version)
 
+        run_cmd = ''
+        if pkgs_to_install:
+            run_as_lst = 'RUN apt-get -y install build-essential && pip install'.split(
+                ' ')
+            run_cmd = ' '.join(run_as_lst + pkgs_to_install)
         with tempfile.NamedTemporaryFile(
                 mode="w+b", suffix="tar") as context_file:
             # Create build context tarfile
@@ -371,8 +384,11 @@ class ClipperConnection(object):
                 context_tar.add(model_data_path)
                 # From https://stackoverflow.com/a/740854/814642
                 df_contents = six.StringIO(
-                    "FROM {container_name}\nCOPY {data_path} /model/\n".format(
-                        container_name=base_image, data_path=model_data_path))
+                    "FROM {container_name}\nCOPY {data_path} /model/\n{run_command}\n".
+                    format(
+                        container_name=base_image,
+                        data_path=model_data_path,
+                        run_command=run_cmd))
                 df_tarinfo = tarfile.TarInfo('Dockerfile')
                 df_contents.seek(0, os.SEEK_END)
                 df_tarinfo.size = df_contents.tell()

--- a/clipper_admin/clipper_admin/deployers/mxnet.py
+++ b/clipper_admin/clipper_admin/deployers/mxnet.py
@@ -28,7 +28,8 @@ def create_endpoint(
         labels=None,
         registry=None,
         base_image="clipper/mxnet-container:{}".format(__version__),
-        num_replicas=1):
+        num_replicas=1,
+        pkgs_to_install=None):
     """Registers an app and deploys the provided predict function with MXNet model as
     a Clipper model.
     Parameters
@@ -83,6 +84,9 @@ def create_endpoint(
         The number of replicas of the model to create. The number of replicas
         for a model can be changed at any time with
         :py:meth:`clipper.ClipperConnection.set_num_replicas`.
+    pkgs_to_install : list (of strings), optional
+        A list of the names of packages to install, using pip, in the container.
+        The names must be strings.
 
     Note
     ----
@@ -97,7 +101,7 @@ def create_endpoint(
                                       slo_micros)
     deploy_mxnet_model(clipper_conn, name, version, input_type, func,
                        mxnet_model, mxnet_data_shapes, base_image, labels,
-                       registry, num_replicas)
+                       registry, num_replicas, pkgs_to_install)
 
     clipper_conn.link_model_to_app(name, name)
 
@@ -113,7 +117,8 @@ def deploy_mxnet_model(
         base_image="clipper/mxnet-container:{}".format(__version__),
         labels=None,
         registry=None,
-        num_replicas=1):
+        num_replicas=1,
+        pkgs_to_install=None):
     """Deploy a Python function with a MXNet model.
     Parameters
     ----------
@@ -152,6 +157,9 @@ def deploy_mxnet_model(
         The number of replicas of the model to create. The number of replicas
         for a model can be changed at any time with
         :py:meth:`clipper.ClipperConnection.set_num_replicas`.
+    pkgs_to_install : list (of strings), optional
+        A list of the names of packages to install, using pip, in the container.
+        The names must be strings.
 
     Note
     ----
@@ -216,9 +224,9 @@ def deploy_mxnet_model(
             json.dump({"data_shapes": mxnet_data_shapes}, f)
 
         # Deploy model
-        clipper_conn.build_and_deploy_model(name, version, input_type,
-                                            serialization_dir, base_image,
-                                            labels, registry, num_replicas)
+        clipper_conn.build_and_deploy_model(
+            name, version, input_type, serialization_dir, base_image, labels,
+            registry, num_replicas, pkgs_to_install)
 
     except Exception as e:
         logger.error("Error saving MXNet model: %s" % e)

--- a/clipper_admin/clipper_admin/deployers/onnx.py
+++ b/clipper_admin/clipper_admin/deployers/onnx.py
@@ -27,7 +27,8 @@ def create_pytorch_endpoint(clipper_conn,
                             base_image=None,
                             num_replicas=1,
                             onnx_backend="caffe2",
-                            batch_size=-1):
+                            batch_size=-1,
+                            pkgs_to_install=None):
     """This function deploys the prediction function with a PyTorch model.
     It serializes the PyTorch model in Onnx format and creates a container that loads it as a Caffe2 model.
     Parameters
@@ -87,13 +88,16 @@ def create_pytorch_endpoint(clipper_conn,
         batches if `batch_size` queries are not immediately available.
         If the default value of -1 is used, Clipper will adaptively calculate the batch size for individual
         replicas of this model.
+    pkgs_to_install : list (of strings), optional
+        A list of the names of packages to install, using pip, in the container.
+        The names must be strings.
     """
 
     clipper_conn.register_application(name, input_type, default_output,
                                       slo_micros)
     deploy_pytorch_model(clipper_conn, name, version, input_type, inputs, func,
                          pytorch_model, base_image, labels, registry,
-                         num_replicas, onnx_backend)
+                         num_replicas, onnx_backend, pkgs_to_install)
 
     clipper_conn.link_model_to_app(name, name)
 
@@ -110,7 +114,8 @@ def deploy_pytorch_model(clipper_conn,
                          registry=None,
                          num_replicas=1,
                          onnx_backend="caffe2",
-                         batch_size=-1):
+                         batch_size=-1,
+                         pkgs_to_install=None):
     """This function deploys the prediction function with a PyTorch model.
     It serializes the PyTorch model in Onnx format and creates a container that loads it as a Caffe2 model.
     Parameters
@@ -155,6 +160,9 @@ def deploy_pytorch_model(clipper_conn,
         batches if `batch_size` queries are not immediately available.
         If the default value of -1 is used, Clipper will adaptively calculate the batch size for individual
         replicas of this model.
+    pkgs_to_install : list (of strings), optional
+        A list of the names of packages to install, using pip, in the container.
+        The names must be strings.
     """
     if base_image is None:
         if onnx_backend is "caffe2":
@@ -172,7 +180,7 @@ def deploy_pytorch_model(clipper_conn,
         # Deploy model
         clipper_conn.build_and_deploy_model(
             name, version, input_type, serialization_dir, base_image, labels,
-            registry, num_replicas, batch_size)
+            registry, num_replicas, batch_size, pkgs_to_install)
 
     except Exception as e:
         logger.error(

--- a/clipper_admin/clipper_admin/deployers/pyspark.py
+++ b/clipper_admin/clipper_admin/deployers/pyspark.py
@@ -27,7 +27,8 @@ def create_endpoint(
         registry=None,
         base_image="clipper/pyspark-container:{}".format(__version__),
         num_replicas=1,
-        batch_size=-1):
+        batch_size=-1,
+        pkgs_to_install=None):
     """Registers an app and deploys the provided predict function with PySpark model as
     a Clipper model.
 
@@ -86,13 +87,16 @@ def create_endpoint(
         batches if `batch_size` queries are not immediately available.
         If the default value of -1 is used, Clipper will adaptively calculate the batch size for individual
         replicas of this model.
+    pkgs_to_install : list (of strings), optional
+        A list of the names of packages to install, using pip, in the container.
+        The names must be strings.
     """
 
     clipper_conn.register_application(name, input_type, default_output,
                                       slo_micros)
     deploy_pyspark_model(clipper_conn, name, version, input_type, func,
                          pyspark_model, sc, base_image, labels, registry,
-                         num_replicas, batch_size)
+                         num_replicas, batch_size, pkgs_to_install)
 
     clipper_conn.link_model_to_app(name, name)
 
@@ -109,7 +113,8 @@ def deploy_pyspark_model(
         labels=None,
         registry=None,
         num_replicas=1,
-        batch_size=-1):
+        batch_size=-1,
+        pkgs_to_install=None):
     """Deploy a Python function with a PySpark model.
 
     The function must take 3 arguments (in order): a SparkSession, the PySpark model, and a list of
@@ -155,6 +160,9 @@ def deploy_pyspark_model(
         batches if `batch_size` queries are not immediately available.
         If the default value of -1 is used, Clipper will adaptively calculate the batch size for individual
         replicas of this model.
+    pkgs_to_install : list (of strings), optional
+        A list of the names of packages to install, using pip, in the container.
+        The names must be strings.
 
     Example
     -------
@@ -225,9 +233,9 @@ def deploy_pyspark_model(
     logger.info("Spark model saved")
 
     # Deploy model
-    clipper_conn.build_and_deploy_model(name, version, input_type,
-                                        serialization_dir, base_image, labels,
-                                        registry, num_replicas, batch_size)
+    clipper_conn.build_and_deploy_model(
+        name, version, input_type, serialization_dir, base_image, labels,
+        registry, num_replicas, batch_size, pkgs_to_install)
 
     # Remove temp files
     shutil.rmtree(serialization_dir)

--- a/clipper_admin/clipper_admin/deployers/python.py
+++ b/clipper_admin/clipper_admin/deployers/python.py
@@ -23,7 +23,8 @@ def create_endpoint(
         registry=None,
         base_image="clipper/python-closure-container:{}".format(__version__),
         num_replicas=1,
-        batch_size=-1):
+        batch_size=-1,
+        pkgs_to_install=None):
     """Registers an application and deploys the provided predict function as a model.
 
     Parameters
@@ -77,13 +78,16 @@ def create_endpoint(
         batches if `batch_size` queries are not immediately available.
         If the default value of -1 is used, Clipper will adaptively calculate the batch size for individual
         replicas of this model.
+    pkgs_to_install : list (of strings), optional
+        A list of the names of packages to install, using pip, in the container.
+        The names must be strings.
     """
 
     clipper_conn.register_application(name, input_type, default_output,
                                       slo_micros)
     deploy_python_closure(clipper_conn, name, version, input_type, func,
                           base_image, labels, registry, num_replicas,
-                          batch_size)
+                          batch_size, pkgs_to_install)
 
     clipper_conn.link_model_to_app(name, name)
 
@@ -98,7 +102,8 @@ def deploy_python_closure(
         labels=None,
         registry=None,
         num_replicas=1,
-        batch_size=-1):
+        batch_size=-1,
+        pkgs_to_install=None):
     """Deploy an arbitrary Python function to Clipper.
 
     The function should take a list of inputs of the type specified by `input_type` and
@@ -140,6 +145,9 @@ def deploy_python_closure(
         batches if `batch_size` queries are not immediately available.
         If the default value of -1 is used, Clipper will adaptively calculate the batch size for individual
         replicas of this model.
+    pkgs_to_install : list (of strings), optional
+        A list of the names of packages to install, using pip, in the container.
+        The names must be strings.
 
     Example
     -------
@@ -183,8 +191,8 @@ def deploy_python_closure(
     serialization_dir = posixpath.join(*os.path.split(serialization_dir))
     logger.info("Python closure saved")
     # Deploy function
-    clipper_conn.build_and_deploy_model(name, version, input_type,
-                                        serialization_dir, base_image, labels,
-                                        registry, num_replicas, batch_size)
+    clipper_conn.build_and_deploy_model(
+        name, version, input_type, serialization_dir, base_image, labels,
+        registry, num_replicas, batch_size, pkgs_to_install)
     # Remove temp files
     shutil.rmtree(serialization_dir)

--- a/clipper_admin/clipper_admin/deployers/pytorch.py
+++ b/clipper_admin/clipper_admin/deployers/pytorch.py
@@ -29,7 +29,8 @@ def create_endpoint(
         registry=None,
         base_image="clipper/pytorch-container:{}".format(__version__),
         num_replicas=1,
-        batch_size=-1):
+        batch_size=-1,
+        pkgs_to_install=None):
     """Registers an app and deploys the provided predict function with PyTorch model as
     a Clipper model.
     Parameters
@@ -85,13 +86,16 @@ def create_endpoint(
         batches if `batch_size` queries are not immediately available.
         If the default value of -1 is used, Clipper will adaptively calculate the batch size for individual
         replicas of this model.
+    pkgs_to_install : list (of strings), optional
+        A list of the names of packages to install, using pip, in the container.
+        The names must be strings.
     """
 
     clipper_conn.register_application(name, input_type, default_output,
                                       slo_micros)
     deploy_pytorch_model(clipper_conn, name, version, input_type, func,
                          pytorch_model, base_image, labels, registry,
-                         num_replicas, batch_size)
+                         num_replicas, batch_size, pkgs_to_install)
 
     clipper_conn.link_model_to_app(name, name)
 
@@ -107,7 +111,8 @@ def deploy_pytorch_model(
         labels=None,
         registry=None,
         num_replicas=1,
-        batch_size=-1):
+        batch_size=-1,
+        pkgs_to_install=None):
     """Deploy a Python function with a PyTorch model.
     Parameters
     ----------
@@ -147,6 +152,9 @@ def deploy_pytorch_model(
         batches if `batch_size` queries are not immediately available.
         If the default value of -1 is used, Clipper will adaptively calculate the batch size for individual
         replicas of this model.
+    pkgs_to_install : list (of strings), optional
+        A list of the names of packages to install, using pip, in the container.
+        The names must be strings.
         
     Example
     -------
@@ -198,9 +206,9 @@ def deploy_pytorch_model(
     logger.info("Torch model saved")
 
     # Deploy model
-    clipper_conn.build_and_deploy_model(name, version, input_type,
-                                        serialization_dir, base_image, labels,
-                                        registry, num_replicas, batch_size)
+    clipper_conn.build_and_deploy_model(
+        name, version, input_type, serialization_dir, base_image, labels,
+        registry, num_replicas, batch_size, pkgs_to_install)
 
     # Remove temp files
     shutil.rmtree(serialization_dir)

--- a/clipper_admin/clipper_admin/deployers/tensorflow.py
+++ b/clipper_admin/clipper_admin/deployers/tensorflow.py
@@ -27,7 +27,8 @@ def create_endpoint(clipper_conn,
                     registry=None,
                     base_image="clipper/tf-container:{}".format(__version__),
                     num_replicas=1,
-                    batch_size=-1):
+                    batch_size=-1,
+                    pkgs_to_install=None):
     """Registers an app and deploys the provided predict function with TensorFlow model as
     a Clipper model.
 
@@ -83,13 +84,17 @@ def create_endpoint(clipper_conn,
         batches if `batch_size` queries are not immediately available.
         If the default value of -1 is used, Clipper will adaptively calculate the batch size for individual
         replicas of this model.
+    pkgs_to_install : list (of strings), optional
+        A list of the names of packages to install, using pip, in the container.
+        The names must be strings.
     """
 
     clipper_conn.register_application(name, input_type, default_output,
                                       slo_micros)
     deploy_tensorflow_model(clipper_conn, name, version, input_type, func,
                             tf_sess_or_saved_model_path, base_image, labels,
-                            registry, num_replicas, batch_size)
+                            registry, num_replicas, batch_size,
+                            pkgs_to_install)
 
     clipper_conn.link_model_to_app(name, name)
 
@@ -105,7 +110,8 @@ def deploy_tensorflow_model(
         labels=None,
         registry=None,
         num_replicas=1,
-        batch_size=-1):
+        batch_size=-1,
+        pkgs_to_install=None):
     """Deploy a Python prediction function with a Tensorflow session or saved Tensorflow model.
     Parameters
     ----------
@@ -145,6 +151,9 @@ def deploy_tensorflow_model(
         batches if `batch_size` queries are not immediately available.
         If the default value of -1 is used, Clipper will adaptively calculate the batch size for individual
         replicas of this model.
+    pkgs_to_install : list (of strings), optional
+        A list of the names of packages to install, using pip, in the container.
+        The names must be strings.
 
     Example
     -------
@@ -250,9 +259,9 @@ def deploy_tensorflow_model(
         logger.info("TensorFlow model copied to: tfmodel ")
 
     # Deploy model
-    clipper_conn.build_and_deploy_model(name, version, input_type,
-                                        serialization_dir, base_image, labels,
-                                        registry, num_replicas, batch_size)
+    clipper_conn.build_and_deploy_model(
+        name, version, input_type, serialization_dir, base_image, labels,
+        registry, num_replicas, batch_size, pkgs_to_install)
 
     # Remove temp files
     shutil.rmtree(serialization_dir)

--- a/integration-tests/deploy_xgboost_models.py
+++ b/integration-tests/deploy_xgboost_models.py
@@ -1,0 +1,134 @@
+import os
+import sys
+import requests
+import json
+import numpy as np
+import time
+import logging
+import xgboost as xgb
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+from test_utils import (create_docker_connection, BenchmarkException, headers,
+                        log_clipper_state)
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.abspath("%s/../clipper_admin" % cur_dir))
+from clipper_admin.deployers.python import deploy_python_closure
+
+logging.basicConfig(
+    format='%(asctime)s %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',
+    datefmt='%y-%m-%d:%H:%M:%S',
+    level=logging.INFO)
+
+logger = logging.getLogger(__name__)
+
+app_name = "xgboost-test"
+model_name = "xgboost-model"
+
+
+def deploy_and_test_model(clipper_conn,
+                          model,
+                          version,
+                          predict_fn,
+                          link_model=False):
+    deploy_python_closure(
+        clipper_conn,
+        model_name,
+        version,
+        "integers",
+        predict_fn,
+        pkgs_to_install=['xgboost'])
+    time.sleep(5)
+
+    if link_model:
+        clipper_conn.link_model_to_app(app_name, model_name)
+        time.sleep(5)
+
+    test_model(clipper_conn, app_name, version)
+
+
+def test_model(clipper_conn, app, version):
+    time.sleep(25)
+    num_preds = 25
+    num_defaults = 0
+    addr = clipper_conn.get_query_addr()
+    for i in range(num_preds):
+        response = requests.post(
+            "http://%s/%s/predict" % (addr, app),
+            headers=headers,
+            data=json.dumps({
+                'input': get_test_point()
+            }))
+        result = response.json()
+        if response.status_code == requests.codes.ok and result["default"]:
+            num_defaults += 1
+        elif response.status_code != requests.codes.ok:
+            print(result)
+            raise BenchmarkException(response.text)
+
+    if num_defaults > 0:
+        print("Error: %d/%d predictions were default" % (num_defaults,
+                                                         num_preds))
+    if num_defaults > num_preds / 2:
+        raise BenchmarkException("Error querying APP %s, MODEL %s:%d" %
+                                 (app, model_name, version))
+
+
+def get_test_point():
+    return [np.random.randint(255) for _ in range(784)]
+
+
+if __name__ == "__main__":
+    pos_label = 3
+    try:
+        clipper_conn = create_docker_connection(
+            cleanup=True, start_clipper=True)
+
+        try:
+            clipper_conn.register_application(app_name, "integers",
+                                              "default_pred", 100000)
+            time.sleep(1)
+
+            addr = clipper_conn.get_query_addr()
+            response = requests.post(
+                "http://%s/%s/predict" % (addr, app_name),
+                headers=headers,
+                data=json.dumps({
+                    'input': get_test_point()
+                }))
+            result = response.json()
+            if response.status_code != requests.codes.ok:
+                print("Error: %s" % response.text)
+                raise BenchmarkException("Error creating app %s" % app_name)
+
+            version = 1
+            dtrain = xgb.DMatrix(get_test_point(), label=[0])
+            param = {
+                'max_depth': 2,
+                'eta': 1,
+                'silent': 1,
+                'objective': 'binary:logistic'
+            }
+            watchlist = [(dtrain, 'train')]
+            num_round = 2
+            bst = xgb.train(param, dtrain, num_round, watchlist)
+
+            def predict(xs):
+                return [str(bst.predict(xgb.DMatrix(xs)))]
+
+            deploy_and_test_model(
+                clipper_conn, bst, version, predict, link_model=True)
+        except BenchmarkException as e:
+            log_clipper_state(clipper_conn)
+            logger.exception("BenchmarkException")
+            clipper_conn = create_docker_connection(
+                cleanup=True, start_clipper=False)
+            sys.exit(1)
+        else:
+            clipper_conn = create_docker_connection(
+                cleanup=True, start_clipper=False)
+    except Exception as e:
+        logger.exception("Exception")
+        clipper_conn = create_docker_connection(
+            cleanup=True, start_clipper=False)
+        sys.exit(1)


### PR DESCRIPTION
…431)

* Implement pip install packages in clipper_con object

* Begin integration test

* Continue work on integration tests

* Add feature to install packages using pip and add integration test for deploy_xgboost_model

* Delete old imports

* Remove extraneous testing code

* Add example for XGBoost

* Fix typo in walkthrough

* Remove Tutorial from this PR

* Add bin/yapf

* Fix formatting

* Add the ability to install packages to all deployers

* Use Python Closure Container deployer

* Fix typo from python_model to python_closure

* Remove unused import

* Add the ability to install packages to all create_endpoint functions

* Take care of unused imports

* updated yapf

* format code